### PR TITLE
CHERRY-PICK: fix wrong video currentTime on wx Android when calling v…

### DIFF
--- a/common/engine/VideoPlayer.js
+++ b/common/engine/VideoPlayer.js
@@ -75,7 +75,7 @@
             self._duration = res.duration;
             self._currentTime = res.position;
         });
-        // onStop not supported
+        // onStop not supported, implemented in promise returned by video.stop call.
     };
 
     _p._unbindEvent = function () {
@@ -196,13 +196,20 @@
     };
 
     _p.stop = function () {
+        let self = this;
         let video = this._video;
         if (!video || !this._visible) return;
 
-        video.stop();
-
-        this._dispatchEvent(_impl.EventType.STOPPED);
-        this._playing = false;
+        video.stop().then(function (res) {
+            if (res.errMsg && !res.errMsg.includes('ok')) {
+                console.error('failed to stop video player');
+                return;
+            }
+            self._currentTime = 0;
+            video.seek(0);  // ensure to set currentTime by 0 when video is stopped
+            self._playing = false;
+            self._dispatchEvent(_impl.EventType.STOPPED);
+        });
     };
 
     _p.setVolume = function (volume) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1916

changLog:
- 修复 安卓上 videoPlayer 停止播放后没有更新 currentTime 的问题

同步之前的修复： https://github.com/cocos-creator-packages/weapp-adapter/pull/115

