### PR TITLE
fix replay audio after audio stop on alipay platform

### DIFF
--- a/common/engine/Audio.js
+++ b/common/engine/Audio.js
@@ -29,8 +29,8 @@ if (Audio) {
 
         stop () {
             if (!this._element) return;
-            this._element.pause();
             this._element.seek(0);
+            this._element.stop();
             this._unbindEnded();
             this.emit('stop');
             this._state = Audio.State.STOPPED;

--- a/common/engine/Audio.js
+++ b/common/engine/Audio.js
@@ -29,6 +29,7 @@ if (Audio) {
 
         stop () {
             if (!this._element) return;
+            // HACK: some platforms won't set currentTime to 0 when stop audio
             this._element.seek(0);
             this._element.stop();
             this._unbindEnded();


### PR DESCRIPTION
changeLog:
- 修复支付宝上停止播放后，又重新开始播放的问题

原因是 audio.seek(0)  之后底层又让他重新播放了。这里直接就调用 audio.stop() 接口吧

之前用` pause() + seek(0)` 主要是因为在微信百度上，调 stop 之后，currentTime 是不会设置为 0 的
但是这个问题本身就不应该是我们来做处理的，stop 之后的 currentTime 是什么，取决于平台方的底层实现。引擎适配层不做处理

以后类似这样的 issue，我们都不应该处理 https://github.com/cocos-creator/2d-tasks/issues/1447
如果真的要解决应该反馈给平台方处理