### PR TITLE
fix cc.sys.os && audio downloading on Alipay iOS

### DIFF
--- a/common/engine/Loader.js
+++ b/common/engine/Loader.js
@@ -83,7 +83,7 @@ function downloadImage (item, callback, isCrossOrigin) {
 
 function downloadAudio (item, callback) {
     if (cc.sys.__audioSupport.format.length === 0) {
-        return new Error(debug.getError(4927));
+        return new Error(cc.debug.getError(4927));
     }
 
     var dom = document.createElement('audio');

--- a/common/engine/globalAdapter/BaseSystemInfo.js
+++ b/common/engine/globalAdapter/BaseSystemInfo.js
@@ -14,13 +14,15 @@ let systemInfo = {
         sys.languageCode = env.language.toLowerCase();
         var system = env.system.toLowerCase();
 
-        if (env.platform === "android") {
+        let platform = env.platform;
+        platform = platform.toLowerCase();
+        if (platform === "android") {
             sys.os = sys.OS_ANDROID;
         }
-        else if (env.platform === "ios") {
+        else if (platform === "ios") {
             sys.os = sys.OS_IOS;
         }
-        else if (env.platform === 'devtools') {
+        else if (platform === 'devtools') {
             sys.isMobile = false;
             if (system.indexOf('android') > -1) {
                 sys.os = sys.OS_ANDROID;

--- a/platforms/alipay/wrapper/engine/Loader.js
+++ b/platforms/alipay/wrapper/engine/Loader.js
@@ -11,7 +11,7 @@ cc.loader.downloader.loadSubpackage = function (name, completeCallback) {
 
 function downloadAudio (item, callback) {
     if (cc.sys.__audioSupport.format.length === 0) {
-        return new Error(debug.getError(4927));
+        return new Error(cc.debug.getError(4927));
     }
 
     let audio = my.createInnerAudioContext();

--- a/platforms/alipay/wrapper/engine/Loader.js
+++ b/platforms/alipay/wrapper/engine/Loader.js
@@ -8,3 +8,29 @@ cc.loader.downloader.loadSubpackage = function (name, completeCallback) {
     }
     completeCallback && completeCallback();
 };
+
+function downloadAudio (item, callback) {
+    if (cc.sys.__audioSupport.format.length === 0) {
+        return new Error(debug.getError(4927));
+    }
+
+    let audio = my.createInnerAudioContext();
+    audio.onCanPlay(() => {
+      callback(null, audio);
+    });
+    audio.onError(() => {
+      callback(new Error('load audio failed ' + item.url), null);
+    });
+    audio.src = item.url;
+}
+
+// FIX audio downlaod error on Alipay iOS 10.1.78
+if (cc.sys.os === cc.sys.OS_IOS) {
+    cc.loader.downloader.addHandlers({
+        // Audio
+        mp3 : downloadAudio,
+        ogg : downloadAudio,
+        wav : downloadAudio,
+        m4a : downloadAudio,
+    });
+}


### PR DESCRIPTION
changeLog:
- 修复部分小游戏平台 `cc.sys.os` 没定义的问题 （原因是 getSystemInfoSync() 接口返回的 platform 大小写不一致）
- 修复支付宝 iOS 上的音频加载一直走 error 回调的问题, （支付宝音频实例复用事件导致，他们将在下个版本修复，不过 2.2 需要做下容错）
<img width="494" alt="20191114170924" src="https://user-images.githubusercontent.com/17872773/68842561-88d14800-0701-11ea-96ea-b532d818f052.png">
