### PR TITLE
use package's name to load subpackage

### DIFF
--- a/common/engine/AssetManager.js
+++ b/common/engine/AssetManager.js
@@ -243,7 +243,7 @@ cc.assetManager.loadBundle = function (root, options, onComplete) {
         }
         options = options || {};
         
-        loadSubpackage(root, options.onProgress, function (err) {
+        loadSubpackage(subpackages.get(root), options.onProgress, function (err) {
             if (err) {
                 onComplete && onComplete(err, null);
                 return;
@@ -285,7 +285,7 @@ if (!isSubDomain) {
     var content = readJsonSync(manifestPath);
     if (content.subpackages) {
         for (var i = 0, l = content.subpackages.length; i < l; i++) {
-            subpackages.add(content.subpackages[i].root, content.subpackages[i]);
+            subpackages.add(content.subpackages[i].root, content.subpackages[i].name);
         }
     }
 }


### PR DESCRIPTION
微信支持用root路径加载子包，但其他平台不敢保证，保险起见还是用包名加载子包吧