### PR TITLE
open es6 project.config.json

### DIFF
--- a/platforms/wechat/res/project.config.json
+++ b/platforms/wechat/res/project.config.json
@@ -3,7 +3,7 @@
 	"miniprogramRoot": "./",
 	"setting": {
 		"urlCheck": true,
-		"es6": false,
+		"es6": true,
 		"postcss": true,
 		"minified": false,
 		"newFeature": false


### PR DESCRIPTION
由于我们适配层转了 es6 ，需要开启开发者工具进行转 es5，免得每次用户要自行去勾选