### PR TITLE
fix cache downloading file

### DIFF
--- a/platforms/alipay/wrapper/fs-utils.js
+++ b/platforms/alipay/wrapper/fs-utils.js
@@ -55,9 +55,13 @@ function deleteFile (filePath, callback) {
 function downloadFile (remoteUrl, filePath, callback) {
     my.downloadFile({
         url: remoteUrl,
-        filePath: filePath,
         success: function (res) {
+          if (!filePath) {
             callback && callback(null, res.apFilePath);
+          }
+          else {
+            saveFile(res.apFilePath, filePath, callback)
+          }
         },
         fail: function (res) {
             console.error('download file failed', res);


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/2132

changeLog:
- 修复支付宝安卓上图片缓存失败的问题


支付宝的 downloadFile 接口不支持指定 filePath 参数