### PR TITLE
force callback

### DIFF
--- a/common/engine/Loader.js
+++ b/common/engine/Loader.js
@@ -92,13 +92,10 @@ function downloadAudio (item, callback) {
     }
 
     var dom = document.createElement('audio');
-    dom.addEventListener('load', function () {
-        callback(null, dom);
-    });
-    dom.addEventListener('error', function () {
-        callback(new Error('load audio failed ' + item.url), null);
-    });
     dom.src = item.url;
+    
+    // HACK: wechat does not callback when load large number of assets
+    callback(null, dom);
 }
 
 function downloadVideo (item, callback) {


### PR DESCRIPTION
微信在加载资源数量很大时，音频加载不回调，估计死锁了。。。只能先强制回调音频了