### PR TITLE
update label material adaption on 2.3.0

### DIFF
--- a/platforms/alipay/wrapper/engine/Label.js
+++ b/platforms/alipay/wrapper/engine/Label.js
@@ -21,12 +21,17 @@ if (cc && cc.Label) {
         });
     });
 
+    let _originUpdateMaterial = Label.prototype._updateMaterialWebgl;
     // fix ttf font black border
     Object.assign(Label.prototype, {
-        setMaterial(index, material) {
-            cc.RenderComponent.prototype.setMaterial.call(this, index, material);
+        _updateMaterialWebgl () {
+            _originUpdateMaterial.call(this);
 
             // init blend factor
+            let material = this._materials[0];
+            if (!this._frame || !material) {
+                return;
+            }
             let dstBlendFactor = cc.macro.BlendFactor.ONE_MINUS_SRC_ALPHA;
             let srcBlendFactor;
             if (!(__globalAdapter.isDevTool || this.font instanceof cc.BitmapFont)) {
@@ -45,8 +50,6 @@ if (cc && cc.Label) {
                 gfx.BLEND_FUNC_ADD,
                 srcBlendFactor, dstBlendFactor,
             );
-
-            material.setDirty(true);
         },
     });
 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2416

changeLog:
- 修复支付宝字体黑边问题

2.3 更新了材质系统，接口也改了，需要更新下