### PR TITLE
fix editbox slice maxLength

### DIFF
--- a/common/engine/Editbox.js
+++ b/common/engine/Editbox.js
@@ -86,10 +86,7 @@
             let delegate = this._delegate;
             let cbs = this._eventListeners;
 
-            cbs.onKeyboardInput = function (res) {        
-                if (res.value.length > delegate.maxLength) {
-                    res.value = res.value.slice(0, delegate.maxLength);
-                }
+            cbs.onKeyboardInput = function (res) {
                 if (delegate._string !== res.value) {
                     delegate.editBoxTextChanged(res.value);
                 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2416

changeLog:
- 修复 EditBox maxLength 为负数时，输入字符串被裁剪的问题