### PR TITLE
fix cannot setFrameRate on Alipay platform

### DIFF
--- a/platforms/alipay/wrapper/unify.js
+++ b/platforms/alipay/wrapper/unify.js
@@ -34,7 +34,8 @@ if (window.__globalAdapter) {
     utils.cloneMethod(globalAdapter, my, 'createInnerAudioContext');
 
     // FrameRate
-    utils.cloneMethod(globalAdapter, my, 'setPreferredFramesPerSecond');
+    // Alipay not supported
+    // utils.cloneMethod(globalAdapter, my, 'setPreferredFramesPerSecond');
 
     // Keyboard
     utils.cloneMethod(globalAdapter, my, 'showKeyboard');


### PR DESCRIPTION
changeLog:
- 修复支付宝平台无法设置帧率的问题


支付宝平台没有支持 setPreferredFramesPerSecond 这个接口，是抽象实现