### PR TITLE
setFrameRate not supported on Alipay platform

### DIFF
--- a/platforms/alipay/wrapper/engine/Game.js
+++ b/platforms/alipay/wrapper/engine/Game.js
@@ -1,0 +1,6 @@
+Object.assign(cc.game, {
+    setFrameRate (frameRate) {
+        // neither my.setPreferredFramesPerSecond() nor window.setTimeout simulating is supported.
+        console.warn('cc.game.setFrameRate() is not supported on Alipay platform.');
+    },
+});

--- a/platforms/alipay/wrapper/engine/index.js
+++ b/platforms/alipay/wrapper/engine/index.js
@@ -1,3 +1,4 @@
 require('./Loader');
 require('./Label');
 require('./Console');
+require('./Game');


### PR DESCRIPTION
changeLog:
- 支付宝上禁用 setFrameRate

同步 2d 的pr: https://github.com/cocos-creator-packages/adapters/pull/104

目前支付宝不能很好的支持通过 window.setTimeout 来模拟帧率控制