### PR TITLE
Revert "fix cannot setFrameRate on Alipay platform (#103)"

### DIFF
--- a/platforms/alipay/wrapper/unify.js
+++ b/platforms/alipay/wrapper/unify.js
@@ -37,8 +37,7 @@ if (window.__globalAdapter) {
     };
 
     // FrameRate
-    // Alipay not supported
-    // utils.cloneMethod(globalAdapter, my, 'setPreferredFramesPerSecond');
+    utils.cloneMethod(globalAdapter, my, 'setPreferredFramesPerSecond');
 
     // Keyboard
     utils.cloneMethod(globalAdapter, my, 'showKeyboard');


### PR DESCRIPTION
This reverts commit 590f022df63d6f4d777c047d9a17262924217b1c.

支付宝将会在 95 版本支持 my. setPreferredFramesPerSecond() 接口，目前暂时先作为已知问题吧
目前这个接口调用不会报错，只是空实现


<img width="667" alt="WechatIMG736" src="https://user-images.githubusercontent.com/17872773/79310118-fd691680-7f2d-11ea-9722-ba4cca005502.png">
