### PR TITLE
Revert "fix cannot setFrameRate on Alipay platform (#102)"

### DIFF
--- a/platforms/alipay/wrapper/unify.js
+++ b/platforms/alipay/wrapper/unify.js
@@ -34,8 +34,7 @@ if (window.__globalAdapter) {
     utils.cloneMethod(globalAdapter, my, 'createInnerAudioContext');
 
     // FrameRate
-    // Alipay not supported
-    // utils.cloneMethod(globalAdapter, my, 'setPreferredFramesPerSecond');
+    utils.cloneMethod(globalAdapter, my, 'setPreferredFramesPerSecond');
 
     // Keyboard
     utils.cloneMethod(globalAdapter, my, 'showKeyboard');


### PR DESCRIPTION
This reverts commit 9aea9b51ee54a638622797ddb65e75bf5fd5c338.

支付宝将会在 95 版本支持  my. setPreferredFramesPerSecond()
已知问题：支付宝不支持设置帧率

同步pr :https://github.com/cocos-creator-packages/adapters/pull/106
