### PR TITLE
fix download remote scripts

### DIFF
--- a/common/engine/AssetManager.js
+++ b/common/engine/AssetManager.js
@@ -269,6 +269,13 @@ cc.assetManager.loadBundle = function (root, options, onComplete) {
     }
 };
 
+cc.assetManager._getScriptPath = function (bundleRoot, bundleVersion) {
+    let path = cc.path;
+    let bundleName = path.basename(bundleRoot);
+    let indexFile = bundleVersion ? `index.${bundleVersion}.js` : 'index.js';
+    return `src/scripts/${bundleName}/${indexFile}`;
+}
+
 if (!isSubDomain) {
     cc.assetManager.transformPipeline.append(function (task) {
         var input = task.output = task.input;

--- a/common/engine/AssetManager.js
+++ b/common/engine/AssetManager.js
@@ -274,7 +274,7 @@ cc.assetManager._getScriptPath = function (bundleRoot, bundleVersion) {
     let bundleName = path.basename(bundleRoot);
     let indexFile = bundleVersion ? `index.${bundleVersion}.js` : 'index.js';
     return `src/scripts/${bundleName}/${indexFile}`;
-}
+};
 
 if (!isSubDomain) {
     cc.assetManager.transformPipeline.append(function (task) {


### PR DESCRIPTION
关联pr: https://github.com/cocos-creator/fireball/pull/9551

changeLog:
- 修复远程脚本加载的问题，目前已经统一将脚本移至  `src/scripts` 目录

<img width="789" alt="WX20200417-174825@2x" src="https://user-images.githubusercontent.com/17872773/79556430-a8670500-80d3-11ea-8fb4-4d6b7c02f7ef.png">
