### PR TITLE
fix xiaomi texture compression support

### DIFF
--- a/platforms/xiaomi/res/package.json
+++ b/platforms/xiaomi/res/package.json
@@ -3,8 +3,8 @@
     "version": "1.0.0",
     "build-template": "xiaomigame",
     "scripts": {
-        "build": "quickgame build --cocos-wx-game --include-file-ext .pem",
-        "release": "quickgame release --cocos-wx-game --include-file-ext .pem",
+        "build": "quickgame build --cocos-wx-game --include-file-ext .pem,.pkm",
+        "release": "quickgame release --cocos-wx-game --include-file-ext .pem,.pkm",
         "server": "quickgame server",
         "debug": "quickgame debug"
     },


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2787

changeLog:
- 小米平台上支持 etc1 压缩纹理

pkm 文件格式会被忽略，需要手动添加白名单