### PR TITLE
add onAudioInterruptionEnd and onAudioInterruptionBegin event call

### DIFF
--- a/common/engine/Game.js
+++ b/common/engine/Game.js
@@ -109,9 +109,9 @@ Object.assign(game, {
                 game.emit(game.EVENT_SHOW, res);
             }
         }
-
-        wx.onAudioInterruptionEnd && wx.onAudioInterruptionEnd(onShown);
-        wx.onAudioInterruptionBegin && wx.onAudioInterruptionBegin(onHidden);
+        
+        __globalAdapter.onAudioInterruptionEnd && __globalAdapter.onAudioInterruptionEnd(onShown);
+        __globalAdapter.onAudioInterruptionBegin && __globalAdapter.onAudioInterruptionBegin(onHidden);
 
         // Maybe not support in open data context
         __globalAdapter.onShow && __globalAdapter.onShow(onShown);

--- a/common/engine/Game.js
+++ b/common/engine/Game.js
@@ -110,6 +110,9 @@ Object.assign(game, {
             }
         }
 
+        wx.onAudioInterruptionEnd && wx.onAudioInterruptionEnd(onShown);
+        wx.onAudioInterruptionBegin && wx.onAudioInterruptionBegin(onHidden);
+
         // Maybe not support in open data context
         __globalAdapter.onShow && __globalAdapter.onShow(onShown);
         __globalAdapter.onHide && __globalAdapter.onHide(onHidden);

--- a/platforms/wechat/wrapper/unify.js
+++ b/platforms/wechat/wrapper/unify.js
@@ -14,6 +14,10 @@ if (window.__globalAdapter) {
     // Audio
     utils.cloneMethod(globalAdapter, wx, 'createInnerAudioContext');
 
+    // AudioInterruption Evnet
+    utils.cloneMethod(globalAdapter, wx, 'onAudioInterruptionEnd');
+    utils.cloneMethod(globalAdapter, wx, 'onAudioInterruptionBegin');
+
     // Video
     utils.cloneMethod(globalAdapter, wx, 'createVideo');
 


### PR DESCRIPTION
Fixed an issue where audio playback could not be automatically resumed when the audio was unexpectedly interrupted

修复音频意外中断时无法自动恢复播放的问题