### PR TITLE
fix crash in open data context on pc-wechat

### DIFF
--- a/platforms/wechat/wrapper/engine/pc-adapter.js
+++ b/platforms/wechat/wrapper/engine/pc-adapter.js
@@ -155,7 +155,7 @@ function adaptMouseEvent () {
 
 (function () {
     // TODO: add mac
-    if (env.platform !== 'windows') {
+    if (__globalAdapter.isSubContext || env.platform !== 'windows') {
         return;
     }
     inputMgr.registerSystemEvent = function () {


### PR DESCRIPTION
resolve https://forum.cocos.org/t/pc-wxsubcontextview/92901

changeLog:
- 修复 pc 微信数据开放域崩溃问题

开放数据与不支持键盘鼠标事件，不过却支持 touch 事件。。。