### PR TITLE
cache unzip file in bundle folder && add patch for alipay ZIP mode on Android

### DIFF
--- a/common/cache-manager.js
+++ b/common/cache-manager.js
@@ -260,7 +260,7 @@ var cacheManager = {
 
     unzipAndCacheBundle (id, zipFilePath, cacheBundleRoot, onComplete) {
         let time = Date.now().toString();
-        let targetPath = `${this.cacheDir}/${time}${suffix++}`;
+        let targetPath = `${this.cacheDir}/${cacheBundleRoot}/${time}${suffix++}`;
         let self = this;
         makeDirSync(targetPath, true);
         unzip(zipFilePath, targetPath, function (err) {

--- a/common/engine/AssetManager.js
+++ b/common/engine/AssetManager.js
@@ -1,5 +1,5 @@
 const cacheManager = require('../cache-manager');
-const { downloadFile, readText, readArrayBuffer, readJson, loadSubpackage, subpackages, remoteBundles, getUserDataPath } = window.fsUtils;
+const { fs, downloadFile, readText, readArrayBuffer, readJson, loadSubpackage, subpackages, remoteBundles, getUserDataPath } = window.fsUtils;
 
 const REGEX = /^\w+:\/\/.*/;
 
@@ -213,7 +213,6 @@ function downloadBundle (url, options, onComplete) {
                     let sys = cc.sys;
                     if (sys.platform === sys.ALIPAY_GAME && sys.os === sys.OS_ANDROID) {
                         let resPath = unzipPath + 'res/';
-                        let fs = my.getFileSystemManager();
                         if (fs.accessSync({path: resPath})) {
                             data.base = resPath;
                         }

--- a/common/engine/AssetManager.js
+++ b/common/engine/AssetManager.js
@@ -212,11 +212,10 @@ function downloadBundle (url, options, onComplete) {
                     // to remove in the future
                     let sys = cc.sys;
                     if (sys.platform === sys.ALIPAY_GAME && sys.os === sys.OS_ANDROID) {
-                        let appVersion = my.getSystemInfoSync().version;
-                        let result = /10\.1\.(\d+)/.exec(appVersion);
-                        result = result && result[1] && Number.parseInt(result[1]);
-                        if (result && result <= 95) {
-                            data.base = unzipPath + 'res/';
+                        let resPath = unzipPath + 'res/';
+                        let fs = my.getFileSystemManager();
+                        if (fs.accessSync({path: resPath})) {
+                            data.base = resPath;
                         }
                     }
                     onComplete && onComplete(null, data);

--- a/common/engine/AssetManager.js
+++ b/common/engine/AssetManager.js
@@ -208,6 +208,17 @@ function downloadBundle (url, options, onComplete) {
                         return;
                     }
                     data.base = unzipPath + '/res/';
+                    // PATCH: for android alipay version before v10.1.95 (v10.1.95 included)
+                    // to remove in the future
+                    let sys = cc.sys;
+                    if (sys.platform === sys.ALIPAY_GAME && sys.os === sys.OS_ANDROID) {
+                        let appVersion = my.getSystemInfoSync().version;
+                        let result = /10\.1\.(\d+)/.exec(appVersion);
+                        result = result && result[1] && Number.parseInt(result[1]);
+                        if (result && result <= 95) {
+                            data.base = unzipPath + 'res/';
+                        }
+                    }
                     onComplete && onComplete(null, data);
                 });
             }


### PR DESCRIPTION
changeLog:
- 将 zip 解压文件缓存到 bundle 目录下
- 兼容支付宝安卓端解压路径的 bug