### PR TITLE
set videoPlayer currentTime duration as 0 by default

### DIFF
--- a/platforms/wechat/wrapper/engine/VideoPlayer.js
+++ b/platforms/wechat/wrapper/engine/VideoPlayer.js
@@ -126,8 +126,8 @@
             this._video = __globalAdapter.createVideo();
             this._video.showCenterPlayBtn = false;
             this._video.controls = false;
-            this._duration = -1;
-            this._currentTime = -1;
+            this._duration = 0;
+            this._currentTime = 0;
             this._loaded = false;
             this.setVisible(false);
             this._bindEvent();


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2900

changeLog:
- 微信 videoPlayer 默认初始 duration currentTime 为 0