### PR TITLE
lengthen socket connect timeout on bytedance platform

### DIFF
--- a/platforms/bytedance/res/game.json
+++ b/platforms/bytedance/res/game.json
@@ -4,7 +4,7 @@
   "openDataContext": "",
   "networkTimeout": {
     "request": 5000,
-    "connectSocket": 5000,
+    "connectSocket": 20000,
     "uploadFile": 5000,
     "downloadFile": 5000
   }


### PR DESCRIPTION
changeLog:
- 延长字节平台的 socket 连接超时

iOS 平台连接速度比较慢，经常时间一到，webSocket 就关了