### PR TITLE
remove label material control

### DIFF
--- a/platforms/bytedance/wrapper/engine/Label.js
+++ b/platforms/bytedance/wrapper/engine/Label.js
@@ -22,36 +22,4 @@ if (cc && cc.Label) {
             });
         });
     }
-
-    let _originUpdateMaterial = Label.prototype._updateMaterialWebgl;
-    // fix ttf font black border
-    Object.assign(Label.prototype, {
-        _updateMaterialWebgl () {
-            _originUpdateMaterial.call(this);
-
-            // init blend factor
-            let material = this._materials[0];
-            if (!this._frame || !material) {
-                return;
-            }
-            let dstBlendFactor = cc.macro.BlendFactor.ONE_MINUS_SRC_ALPHA;
-            let srcBlendFactor;
-            if (!(globalAdapter.isDevTool || this.font instanceof cc.BitmapFont)) {
-                // Premultiplied alpha on runtime
-                srcBlendFactor = cc.macro.BlendFactor.ONE;
-            }
-            else {
-                srcBlendFactor = cc.macro.BlendFactor.SRC_ALPHA;
-            }
-
-            // set blend func
-            material.effect.setBlend(
-                true,
-                gfx.BLEND_FUNC_ADD,
-                srcBlendFactor, dstBlendFactor,
-                gfx.BLEND_FUNC_ADD,
-                srcBlendFactor, dstBlendFactor,
-            );
-        },
-    });
 }


### PR DESCRIPTION
resolve: https://forum.cocos.org/t/2-4-2-label-bmpfont-gl-one/96597

changeLog:
- 移除 Label 的材质设置

之前为了解决一些字体黑边的问题，强制更改了 label 的混合模式，
v2.4 里支持了 label 组件的混合模式修改，这部分逻辑可以移除了。
保留着反而会干扰开发者的配置