### PR TITLE
fix video rendering on ByteDance platform

### DIFF
--- a/platforms/bytedance/wrapper/engine/ImageAsset.js
+++ b/platforms/bytedance/wrapper/engine/ImageAsset.js
@@ -1,0 +1,7 @@
+if (cc.ImageAsset) {
+    Object.defineProperty(cc.ImageAsset.prototype, 'data', {
+        get () {
+            return this._nativeData._data || this._nativeData;
+        },
+    });
+}

--- a/platforms/bytedance/wrapper/engine/index.js
+++ b/platforms/bytedance/wrapper/engine/index.js
@@ -1,2 +1,3 @@
 require('./Label');
 require('./Loader');
+require('./ImageAsset');


### PR DESCRIPTION
resolve: https://forum.cocos.org/t/creator3d1-2-0-createcamera/98750

changeLog:
- 修复字节渲染 video，提交纹理时出错的问题

目前字节推荐的实现，是将 video 当作纹理提交到 imageAsset，这块就不能使用类型判断 isNativeImage 了

参考字节文档：
https://bytedance.feishu.cn/docs/doccnmavSRbCHJR3yaCggTG8uhh#jvowYo
