### PR TITLE
fix avatar loading

### DIFF
--- a/platforms/bytedance/wrapper/fs-utils.js
+++ b/platforms/bytedance/wrapper/fs-utils.js
@@ -69,6 +69,11 @@ var fsUtils = {
                 }
             },
             fail: function (res) {
+                // straightfully return the remoteUrl because image url out of whitelist
+                // can't be downloaded on bytedance platform
+                if (res.errMsg && res.errMsg.includes('Failed to load')) {
+                    return onComplete && onComplete(null, remoteUrl);
+                }
                 console.warn(`Download file failed: path: ${remoteUrl} message: ${res.errMsg}`);
                 onComplete && onComplete(new Error(res.errMsg), null);
             }


### PR DESCRIPTION
re: https://forum.cocos.org/t/topic/100054

changeLog:
- 判断字节平台 downloadFile 失败是否因为白名单的问题，如果是，直接返回 remoteUrl

## 错误信息
我们没有线上的测试环境，据字节团队反馈，白名单导致下载失败，会返回以下错误信息
可以借此作为判断的依据
![Lark20201125-161653](https://user-images.githubusercontent.com/17872773/100200540-bc13fd00-2f39-11eb-9ce8-3830ea709497.png)

## 开发者需要做的
在加载字节的头像时，传入选项，禁用文件缓存
```
cc.assetManager.loadRemote('https://xxx.png', {
     cacheEnabled: false,    //  <-------------
}, callback);
```
