### PR TITLE
Fixed-where-the-game's-black-screen-stuck-when-connecting-to-a-WeChat…

### DIFF
--- a/common/engine/Game.js
+++ b/common/engine/Game.js
@@ -127,8 +127,13 @@ Object.assign(game, {
             }
         }
         
-        __globalAdapter.onAudioInterruptionEnd && __globalAdapter.onAudioInterruptionEnd(onShown);
-        __globalAdapter.onAudioInterruptionBegin && __globalAdapter.onAudioInterruptionBegin(onHidden);
+        __globalAdapter.onAudioInterruptionEnd && __globalAdapter.onAudioInterruptionEnd(function () {
+            if (cc.audioEngine) cc.audioEngine._restore();
+            
+        });
+        __globalAdapter.onAudioInterruptionBegin && __globalAdapter.onAudioInterruptionBegin(function () {
+            if (cc.audioEngine) cc.audioEngine._break();
+        });
 
         // Maybe not support in open data context
         __globalAdapter.onShow && __globalAdapter.onShow(onShown);


### PR DESCRIPTION
修改原因：

测试了 onAudioInterruptionBegin 和 onAudioInterruptionEnd 接口，语音进来的时候触发 Begin ，只有当用户结束语音通话的时候才会触发 End。所以在这期间用户如果回到游戏，游戏依然被引擎调用的 game.pause 暂停着。此时因为回到游戏时，微信小游戏也没有触发 onShow 回调，所以一直黑屏着。

复现测试方法：

demo：
[001.zip](https://github.com/cocos-creator-packages/adapters/files/5878524/001.zip)


将 demo 构建微信小游戏后，扫码预览，然后在 A 手机微信上点击游戏按钮播放背景音乐。

拿 B 手机拨打 A 手机的微信电话。

接通微信电话之后，缩小通话窗口，回到游戏查看游戏画面是否还能显示。