### PR TITLE
修正 "横着拿iPad 玩竖屏微信小游戏" 时, safeArea错误的问题.

### DIFF
--- a/platforms/wechat/wrapper/unify.js
+++ b/platforms/wechat/wrapper/unify.js
@@ -6,7 +6,12 @@ if (window.__globalAdapter) {
     let systemInfo = wx.getSystemInfoSync();
     let windowWidth = systemInfo.windowWidth;
     let windowHeight = systemInfo.windowHeight;
-    let isLandscape = windowWidth > windowHeight;
+
+    let screenWidth = systemInfo.screenWidth;
+    let screenHeight = systemInfo.screenHeight;
+    let orientation = systemInfo.deviceOrientation;
+    let isLandscape = orientation ? (orientation === "landscape"): (screenWidth > screenHeight);
+
     globalAdapter.isSubContext = (wx.getOpenDataContext === undefined);
     globalAdapter.isDevTool = (systemInfo.platform === 'devtools');
     utils.cloneMethod(globalAdapter, wx, 'getSystemInfoSync');


### PR DESCRIPTION
其他 小游戏平台,  以及其他 pad 没有测试 和 修改. 请 cocos官方去验证核实一下吧.

主要原因是.  微信小游戏上 不能用  windowWidth/windowHeight 来判断是不是landscape , 要用 screenWidth/screenHeight .