### PR TITLE
解决 微信小游戏新版本在 iOS下, 偶尔取不到 某些属性 引起的bug.

### DIFF
--- a/common/engine/globalAdapter/BaseSystemInfo.js
+++ b/common/engine/globalAdapter/BaseSystemInfo.js
@@ -3,7 +3,7 @@ function adaptSys (sys, env) {
         env = __globalAdapter.getSystemInfoSync();
     }
 
-    var language = env.language || 'unknown';
+    var language = env.language || '';
     var system = env.system || 'iOS';
     var platform = env.platform || 'iOS';
 

--- a/common/engine/globalAdapter/BaseSystemInfo.js
+++ b/common/engine/globalAdapter/BaseSystemInfo.js
@@ -2,14 +2,17 @@ function adaptSys (sys, env) {
     if (!env) {
         env = __globalAdapter.getSystemInfoSync();
     }
+
+    var language = env.language || 'unknown';
+    var system = env.system || 'iOS';
+    var platform = env.platform || 'iOS';
+
     sys.isNative = false;
     sys.isBrowser = false;
     sys.isMobile = true;
-    sys.language = env.language.substr(0, 2);
-    sys.languageCode = env.language.toLowerCase();
-    var system = env.system.toLowerCase();
+    sys.language = language.substr(0, 2);
+    sys.languageCode = language.toLowerCase();
 
-    let platform = env.platform;
     platform = platform.toLowerCase();
     if (platform === "android") {
         sys.os = sys.OS_ANDROID;
@@ -18,6 +21,7 @@ function adaptSys (sys, env) {
         sys.os = sys.OS_IOS;
     }
 
+    system = system.toLowerCase();
     // Adaptation to Android P
     if (system === 'android p') {
         system = 'android p 9.0';

--- a/platforms/wechat/wrapper/builtin/navigator.js
+++ b/platforms/wechat/wrapper/builtin/navigator.js
@@ -9,7 +9,7 @@ const platform = systemInfo.platform;
 const language = systemInfo.language;
 const wechatVersioin = systemInfo.version;
 
-const android = system.toLowerCase().indexOf('android') !== -1;
+const android = system ? system.toLowerCase().indexOf('android') !== -1 : false;
 
 const uaDesc = android ? `Android; CPU ${system}` : `iPhone; CPU iPhone OS ${system} like Mac OS X`;
 const ua = `Mozilla/5.0 (${uaDesc}) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E8301 MicroMessenger/${wechatVersioin} MiniGame NetType/WIFI Language/${language}`;


### PR DESCRIPTION
 微信小游戏iOS版本,  基础库版本 2.15.0 ,  偶尔会出现取不到 system. 从而引起 `undefined is not an object (evaluating 'i.toLowerCase')` 异常.

该commit用于修正此问题.

(只是临时解决方案, 最终方案肯定还要 微信方面去解决)