### PR TITLE
optimize Label black border on bytedance platform

### DIFF
--- a/platforms/bytedance/wrapper/engine/Label.js
+++ b/platforms/bytedance/wrapper/engine/Label.js
@@ -22,4 +22,38 @@ if (cc && cc.Label) {
             });
         });
     }
+
+    // need to fix ttf font black border at the sdk verion lower than 2.0.0
+    let sysInfo = tt.getSystemInfoSync();
+    if (Number.parseInt(sysInfo.SDKVersion[0]) < 2) {
+        let _originUpdateMaterial = Label.prototype._updateMaterialWebgl;
+        Object.assign(Label.prototype, {
+            _updateMaterialWebgl () {
+                _originUpdateMaterial.call(this);
+                // only fix when srcBlendFactor is SRC_ALPHA
+                if (this.srcBlendFactor !== cc.macro.BlendFactor.SRC_ALPHA
+                    || globalAdapter.isDevTool || this.font instanceof cc.BitmapFont) {
+                    return;
+                }
+    
+                // init blend factor
+                let material = this._materials[0];
+                if (!this._frame || !material) {
+                    return;
+                }
+                let dstBlendFactor = this.dstBlendFactor;
+                // Premultiplied alpha on runtime when sdk verion is lower than 2.0.0
+                let srcBlendFactor = cc.macro.BlendFactor.ONE;
+    
+                // set blend func
+                material.effect.setBlend(
+                    true,
+                    gfx.BLEND_FUNC_ADD,
+                    srcBlendFactor, dstBlendFactor,
+                    gfx.BLEND_FUNC_ADD,
+                    srcBlendFactor, dstBlendFactor,
+                );
+            },
+        });
+    }
 }


### PR DESCRIPTION
# changeLog
- 优化字节的文字黑边问题的处理

## 背景
- 字节 SDKVersion < 2.0.0 的版本里，默认是开启预乘的，此时如果用户配置 Label 组件的 srcBlendFactor 为 SRC_ALPHA 时，引擎应该帮用户改为 ONE 才是符合用户预期的
- 字节在 SDKVersion 2.0.0 后修复了预乘问题，这时候就不需要这部分修复了
- 这个 pr 旨在兼容 2.0.0 版本之前的问题

# 修复前
<img width="247" alt="1" src="https://user-images.githubusercontent.com/17872773/109769999-f6c2bb00-7c35-11eb-9f23-f75c96ebb7a2.png">

# 修复后
<img width="247" alt="2" src="https://user-images.githubusercontent.com/17872773/109770023-fde9c900-7c35-11eb-97c8-d6bf93a9bfd0.png">

# 相关说明：
- 该修复针对 v2.4.3 以上的版本（包括 v2.4.3）  
- 如果你使用的是 Cocos Creator v2.4.1 ~ V2.4.2 版本的项目，请直接将 Label.js 文件覆盖掉该路径下的脚本  
编辑器目录/resources/builtin/adapters/platforms/bytedance/wrapper/engine/Label.js
- 如果你使用的是 3.x 版本的项目，请参考这里的 pr 修复 https://github.com/cocos-creator/engine/pull/8319


## 版本差异详情可以参考文档：
https://bytedance.feishu.cn/docs/doccnBnJHSJEjlZCKu210TGv8Wg