### PR TITLE
防止 cc.Canvas.instance 不存在时报错.

### DIFF
--- a/platforms/wechat/wrapper/error-reporter.js
+++ b/platforms/wechat/wrapper/error-reporter.js
@@ -14,7 +14,12 @@ function onErrorMessageHandler (info) {
     if (!env) {
         return;
     }
-    var root = cc.Canvas.instance ? cc.Canvas.instance.node : null;
+
+    if (!cc.Canvas.instance) {
+        return;
+    }
+
+    var root = cc.Canvas.instance.node
     if (!root) {
         return;
     }

--- a/platforms/wechat/wrapper/error-reporter.js
+++ b/platforms/wechat/wrapper/error-reporter.js
@@ -14,7 +14,7 @@ function onErrorMessageHandler (info) {
     if (!env) {
         return;
     }
-    var root = cc.Canvas.instance.node;
+    var root = cc.Canvas.instance ? cc.Canvas.instance.node : null;
     if (!root) {
         return;
     }


### PR DESCRIPTION
实际项目中 遇到过 因为 cc.Canvas.instance 不存在, 而导致 cc.Canvas.instance.node 报错的问题.
```

null is not an object (evaluating \'cc.Canvas.instance.node\')
e@https://usr//subpackages/engine/game.js:3:89568
t@https://lib/WAGameSubContext.js:2:158613
https://lib/WAGame.js:2:1540573
https://lib/WAGame.js:2:1849465

```

不知道 为什么. 另外 也不知道 其他平台入 字节小游戏 oppo小游戏等 会不会也有类似问题.
我只测试了 wexin. 所以暂时只给微信提这个pr了.

其他的平台 麻烦 @jareguo 看一下吧.
