### PR TITLE
fix wrong safe area on iOS device

### DIFF
--- a/platforms/bytedance/wrapper/unify.js
+++ b/platforms/bytedance/wrapper/unify.js
@@ -119,6 +119,13 @@ if (window.__globalAdapter) {
     // origin point on the top-left corner
     globalAdapter.getSafeArea = function () {
         let { top, left, bottom, right, width, height } = systemInfo.safeArea;
+        // HACK: on iOS device, the orientation should mannually rotate
+        if (systemInfo.platform === 'ios' && !globalAdapter.isDevTool && isLandscape) {
+            let tmpTop = top, tmpLeft = left, tmpBottom = bottom, tmpRight = right, tmpWidth = width, tmpHeight = height;
+            top = tmpLeft;
+            left = tmpTop;
+            right = tmpRight - tmpTop;
+        }
         return { top, left, bottom, right, width, height };
     }
 }

--- a/platforms/wechat/wrapper/unify.js
+++ b/platforms/wechat/wrapper/unify.js
@@ -125,14 +125,14 @@ if (window.__globalAdapter) {
     globalAdapter.getSafeArea = function () {
         let { top, left, bottom, right, width, height } = systemInfo.safeArea;
         // HACK: on iOS device, the orientation should mannually rotate
-            let tempData = [right, top, left, bottom, width, height];
-            top = windowHeight - tempData[0];
-            left = tempData[1];
-            bottom = windowHeight - tempData[2];
-            right = tempData[3];
-            height = tempData[4];
-            width = tempData[5];
         if (systemInfo.platform === 'ios' && !globalAdapter.isDevTool && isLandscape()) {
+            let tmpTop = top, tmpLeft = left, tmpBottom = bottom, tmpRight = right, tmpWidth = width, tmpHeight = height;
+            top = windowHeight - tmpRight;
+            left = tmpTop;
+            bottom = windowHeight - tmpLeft;
+            right = tmpBottom;
+            height = tmpWidth;
+            width = tmpHeight;
         }
         return { top, left, bottom, right, width, height };
     }

--- a/platforms/wechat/wrapper/unify.js
+++ b/platforms/wechat/wrapper/unify.js
@@ -1,16 +1,16 @@
 const utils = require('../../../common/utils');
 
+// NOTE: size and orientation info is wrong at the init phase, especially on iOS device
+function isLandscape () {
+    let systemInfo = wx.getSystemInfoSync();
+    return systemInfo.deviceOrientation ? (systemInfo.deviceOrientation === "landscape"): (systemInfo.screenWidth > systemInfo.screenHeight);
+}
 if (window.__globalAdapter) {
     let globalAdapter = window.__globalAdapter;
     // SystemInfo
     let systemInfo = wx.getSystemInfoSync();
     let windowWidth = systemInfo.windowWidth;
     let windowHeight = systemInfo.windowHeight;
-
-    let screenWidth = systemInfo.screenWidth;
-    let screenHeight = systemInfo.screenHeight;
-    let orientation = systemInfo.deviceOrientation;
-    let isLandscape = orientation ? (orientation === "landscape"): (screenWidth > screenHeight);
 
     globalAdapter.isSubContext = (wx.getOpenDataContext === undefined);
     globalAdapter.isDevTool = (systemInfo.platform === 'devtools');
@@ -86,7 +86,7 @@ if (window.__globalAdapter) {
                     let resClone = {};
                     let x = res.x;
                     let y = res.y;
-                    if (isLandscape) {
+                    if (isLandscape()) {
                         let tmp = x;
                         x = -y;
                         y = tmp;
@@ -125,7 +125,6 @@ if (window.__globalAdapter) {
     globalAdapter.getSafeArea = function () {
         let { top, left, bottom, right, width, height } = systemInfo.safeArea;
         // HACK: on iOS device, the orientation should mannually rotate
-        if (systemInfo.platform === 'ios' && !globalAdapter.isDevTool && isLandscape) {
             let tempData = [right, top, left, bottom, width, height];
             top = windowHeight - tempData[0];
             left = tempData[1];
@@ -133,6 +132,7 @@ if (window.__globalAdapter) {
             right = tempData[3];
             height = tempData[4];
             width = tempData[5];
+        if (systemInfo.platform === 'ios' && !globalAdapter.isDevTool && isLandscape()) {
         }
         return { top, left, bottom, right, width, height };
     }

--- a/platforms/wechat/wrapper/unify.js
+++ b/platforms/wechat/wrapper/unify.js
@@ -127,11 +127,12 @@ if (window.__globalAdapter) {
         // HACK: on iOS device, the orientation should mannually rotate
         if (systemInfo.platform === 'ios' && !globalAdapter.isDevTool && isLandscape()) {
             let tmpTop = top, tmpLeft = left, tmpBottom = bottom, tmpRight = right, tmpWidth = width, tmpHeight = height;
+            let bottomHeight = windowWidth - tmpBottom;
             top = windowHeight - tmpRight;
             left = tmpTop;
-            bottom = windowHeight - tmpLeft;
+            bottom = windowHeight - tmpLeft - bottomHeight;
             right = tmpBottom;
-            height = tmpWidth;
+            height = tmpWidth - bottomHeight;
             width = tmpHeight;
         }
         return { top, left, bottom, right, width, height };


### PR DESCRIPTION
resolve: https://github.com/cocos-creator/2d-tasks/issues/3298

changeLog:
- 修复 微信和字节 iOS 端上获取安全区域不正确的问题


正常的行为：
<img width="666" alt="企业微信20210323-153142@2x" src="https://user-images.githubusercontent.com/17872773/112109757-e8404180-8bec-11eb-8067-8e2c1d1112b2.png">

![1](https://user-images.githubusercontent.com/17872773/112108244-e4132480-8bea-11eb-9693-f603017e3627.jpg)

![2](https://user-images.githubusercontent.com/17872773/112108258-e9706f00-8bea-11eb-9eef-ef7d23fb923f.jpg)

