### PR TITLE
run on Taobao runtime environment

### DIFF
--- a/platforms/taobao/index.js
+++ b/platforms/taobao/index.js
@@ -12,7 +12,7 @@ Object.assign(adapter, {
     },
 
     adaptEngine () {
-        require('./wrapper/engine');
         require('../../common/engine');
+        require('./wrapper/engine');
     },
 });

--- a/platforms/taobao/res/app.js
+++ b/platforms/taobao/res/app.js
@@ -1,3 +1,6 @@
+var onShowCB;
+var onHideCB;
+
 App({
   onLaunch(options) {
     console.info('App onLaunched');
@@ -21,11 +24,18 @@ App({
       
       window.boot();
     };
+
+    __globalAdapter.onShow = function (cb) {
+      onShowCB = cb;
+    };
+    __globalAdapter.onHide = function (cb) {
+      onHideCB = cb;
+    };
   },
   onShow(options) {
-    // TODO: implement onShow
+    onShowCB && onShowCB();
   },
   onHide(options) {
-    // TODO: implement onHide
+    onHideCB && onHideCB();
   },
 });

--- a/platforms/taobao/res/global-variables.js
+++ b/platforms/taobao/res/global-variables.js
@@ -7,4 +7,4 @@ var __globalAdapter = window.__globalAdapter = window.__globalAdapter || {};
 var __cocos_require__ = window.__cocos_require__;
 var Image = window.Image;
 var document = window.document;
-
+var DOMParser = window.DOMParser;

--- a/platforms/taobao/res/global-variables.js
+++ b/platforms/taobao/res/global-variables.js
@@ -6,5 +6,8 @@ var dragonBones = window.dragonBones = window.dragonBones || {};
 var __globalAdapter = window.__globalAdapter = window.__globalAdapter || {};
 var __cocos_require__ = window.__cocos_require__;
 var Image = window.Image;
+var HTMLCanvasElement = window.HTMLCanvasElement;
+var HTMLImageElement = window.HTMLImageElement;
+var ImageBitmap = window.ImageBitmap;
 var document = window.document;
 var DOMParser = window.DOMParser;

--- a/platforms/taobao/res/global-variables.js
+++ b/platforms/taobao/res/global-variables.js
@@ -11,3 +11,4 @@ var HTMLImageElement = window.HTMLImageElement;
 var ImageBitmap = window.ImageBitmap;
 var document = window.document;
 var DOMParser = window.DOMParser;
+var performance = window.performance;

--- a/platforms/taobao/res/mini.project.json
+++ b/platforms/taobao/res/mini.project.json
@@ -8,6 +8,16 @@
         "**/assets/**/*.ab",
         "**/assets/**/*.mp3",
         "**/assets/**/*.mp4",
-        "**/assets/**/*.plist"
+        "**/assets/**/*.plist",
+
+        "**/remote/**/*.ktx",
+        "**/remote/**/*.json",
+        "**/remote/**/*.txt",
+        "**/remote/**/*.fnt",
+        "**/remote/**/*.bin",
+        "**/remote/**/*.ab",
+        "**/remote/**/*.mp3",
+        "**/remote/**/*.mp4",
+        "**/remote/**/*.plist"
     ]
 }

--- a/platforms/taobao/res/pages/index/index.js
+++ b/platforms/taobao/res/pages/index/index.js
@@ -2,6 +2,20 @@ var touchstartCB;
 var touchcancelCB;
 var touchendCB;
 var touchmoveCB;
+
+function handleTouchEvent (event) {
+	if (my.isIDE) {
+		return;
+	}
+	let changedTouches = event.changedTouches;
+	if (changedTouches) {
+		for (let touch of changedTouches) {
+			touch.clientX = touch.x;
+			touch.clientY = touch.y;
+		}
+	}
+}
+
 Page({
 	onReady () {
 		__globalAdapter.onTouchStart = function (cb) {
@@ -31,15 +45,19 @@ Page({
 		console.error('error in page: ', err);
 	},
 	onTouchStart (event) {
+		handleTouchEvent(event);
 		touchstartCB && touchstartCB(event);
 	},
 	onTouchCancel (event) {
+		handleTouchEvent(event);
 		touchcancelCB && touchcancelCB(event);
 	},
 	onTouchEnd (event) {
+		handleTouchEvent(event);
 		touchendCB && touchendCB(event);
 	},
 	onTouchMove (event) {
+		handleTouchEvent(event);
 		touchmoveCB && touchmoveCB(event);
 	},
 	canvasOnReady () {

--- a/platforms/taobao/wrapper/builtin/Canvas.js
+++ b/platforms/taobao/wrapper/builtin/Canvas.js
@@ -1,59 +1,69 @@
 import { innerWidth, innerHeight } from './WindowProperties'
 
-export default function Canvas() {
-  const canvas = my.createOffscreenCanvas()
+function Canvas () {}
 
-  canvas.type = 'canvas'
+let CanvasProxy = new Proxy(Canvas, {
+  construct () {
 
-  // canvas.__proto__.__proto__.__proto__ = new HTMLCanvasElement()
+    const canvas = my.createOffscreenCanvas()
 
-  const _getContext = canvas.getContext
-
-  canvas.getBoundingClientRect = () => {
-    const ret = {
-      top: 0,
-      left: 0,
-      width: window.innerWidth,
-      height: window.innerHeight
+    canvas.type = 'canvas'
+  
+    // canvas.__proto__.__proto__.__proto__ = new HTMLCanvasElement()
+  
+    const _getContext = canvas.getContext
+  
+    canvas.getBoundingClientRect = () => {
+      const ret = {
+        top: 0,
+        left: 0,
+        width: window.innerWidth,
+        height: window.innerHeight
+      }
+      return ret
     }
-    return ret
-  }
-
-  canvas.style = {
-    top: '0px',
-    left: '0px',
-    width: innerWidth + 'px',
-    height: innerHeight + 'px',
-  }
-
-  canvas.addEventListener = function (type, listener, options = {}) {
-    // console.log('canvas.addEventListener', type);
-    document.addEventListener(type, listener, options);
-  }
-
-  canvas.removeEventListener = function (type, listener) {
-    // console.log('canvas.removeEventListener', type);
-    document.removeEventListener(type, listener);
-  }
-
-  canvas.dispatchEvent = function (event = {}) {
-    console.log('canvas.dispatchEvent' , event.type, event);
-    // nothing to do
-  }
-
-  Object.defineProperty(canvas, 'clientWidth', {
-    enumerable: true,
-    get: function get() {
-      return innerWidth
+  
+    canvas.style = {
+      top: '0px',
+      left: '0px',
+      width: innerWidth + 'px',
+      height: innerHeight + 'px',
     }
-  })
-
-  Object.defineProperty(canvas, 'clientHeight', {
-    enumerable: true,
-    get: function get() {
-      return innerHeight
+  
+    canvas.addEventListener = function (type, listener, options = {}) {
+      // console.log('canvas.addEventListener', type);
+      document.addEventListener(type, listener, options);
     }
-  })
+  
+    canvas.removeEventListener = function (type, listener) {
+      // console.log('canvas.removeEventListener', type);
+      document.removeEventListener(type, listener);
+    }
+  
+    canvas.dispatchEvent = function (event = {}) {
+      console.log('canvas.dispatchEvent' , event.type, event);
+      // nothing to do
+    }
+  
+    Object.defineProperty(canvas, 'clientWidth', {
+      enumerable: true,
+      get: function get() {
+        return innerWidth
+      }
+    })
+  
+    Object.defineProperty(canvas, 'clientHeight', {
+      enumerable: true,
+      get: function get() {
+        return innerHeight
+      }
+    })
+  
+    return canvas
+  },
+});
 
-  return canvas
-}
+// NOTE: this is a hack operation
+// let canvas = new window.Canvas()
+// console.error(canvas instanceof window.Canvas)  => false
+export default CanvasProxy;

--- a/platforms/taobao/wrapper/builtin/HTMLCanvasElement.js
+++ b/platforms/taobao/wrapper/builtin/HTMLCanvasElement.js
@@ -1,2 +1,3 @@
-export Canvas from './Canvas'
+let HTMLCanvasElement = my.createOffscreenCanvas().constructor;
 
+export default HTMLCanvasElement;

--- a/platforms/taobao/wrapper/builtin/HTMLImageElement.js
+++ b/platforms/taobao/wrapper/builtin/HTMLImageElement.js
@@ -1,1 +1,4 @@
-export imageConstructor from './Image';
+var screencanvas = $global.screencanvas;
+let HTMLImageElement =  screencanvas.createImage().constructor;
+
+export default HTMLImageElement;

--- a/platforms/taobao/wrapper/builtin/Image.js
+++ b/platforms/taobao/wrapper/builtin/Image.js
@@ -5,7 +5,27 @@ function Image () {
 }
 let ImageProxy = new Proxy(Image, {
     construct (target, args) {
-        return screencanvas.createImage();
+        let img =  screencanvas.createImage();
+        if (!img.addEventListener) {
+            img.addEventListener = function (eventName, eventCB) {
+                if (eventName === 'load') {
+                    img.onload = eventCB;
+                } else if (eventName === 'error') {
+                    img.onerror = eventCB;
+                }
+            };
+        }
+
+        if (!img.removeEventListener) {
+          img.removeEventListener = function (eventName) {
+            if (eventName === 'load') {
+              img.onload = null;
+            } else if (eventName === 'error') {
+              img.onerror = null;
+            }
+          };
+        }
+        return img;
     },
 });
 

--- a/platforms/taobao/wrapper/builtin/ImageBitmap.js
+++ b/platforms/taobao/wrapper/builtin/ImageBitmap.js
@@ -1,0 +1,5 @@
+export default class ImageBitmap {
+    constructor() {
+        // TODO
+    }
+}

--- a/platforms/taobao/wrapper/builtin/WindowProperties.js
+++ b/platforms/taobao/wrapper/builtin/WindowProperties.js
@@ -1,7 +1,15 @@
-const { pixelRatio } = my.getSystemInfoSync()
+const { pixelRatio, screenWidth, screenHeight } = my.getSystemInfoSync()
 const devicePixelRatio = pixelRatio;
 
-let { width, height } = $global.screencanvas.getBoundingClientRect();
+let width, height;
+if ($global.screencanvas.getBoundingClientRect) {
+  let rect = $global.screencanvas.getBoundingClientRect();
+  width = rect.width;
+  height = rect.height;
+} else {
+  width = screenWidth;
+  height = screenHeight;
+}
 export const innerWidth = width;
 export const innerHeight = height;
 export { devicePixelRatio }

--- a/platforms/taobao/wrapper/builtin/WindowProperties.js
+++ b/platforms/taobao/wrapper/builtin/WindowProperties.js
@@ -1,4 +1,4 @@
-const { pixelRatio, screenWidth, screenHeight } = my.getSystemInfoSync()
+const { pixelRatio, windowWidth, windowHeight } = my.getSystemInfoSync()
 const devicePixelRatio = pixelRatio;
 
 let width, height;
@@ -7,8 +7,8 @@ if ($global.screencanvas.getBoundingClientRect) {
   width = rect.width;
   height = rect.height;
 } else {
-  width = screenWidth;
-  height = screenHeight;
+  width = windowWidth;
+  height = windowHeight;
 }
 export const innerWidth = width;
 export const innerHeight = height;

--- a/platforms/taobao/wrapper/builtin/cancelAnimationFrame.js
+++ b/platforms/taobao/wrapper/builtin/cancelAnimationFrame.js
@@ -1,0 +1,4 @@
+let screencanvas = $global.screencanvas;
+let cancelAnimationFrame = screencanvas.cancelAnimationFrame.bind(screencanvas);
+
+export default cancelAnimationFrame;

--- a/platforms/taobao/wrapper/builtin/document.js
+++ b/platforms/taobao/wrapper/builtin/document.js
@@ -21,6 +21,7 @@ var document = {
   body: new HTMLElement('body'),
 
   createElement(tagName) {
+    tagName = tagName.toLowerCase();
     if (tagName === 'canvas') {
       return new Canvas()
     } else if (tagName === 'audio') {

--- a/platforms/taobao/wrapper/builtin/localStorage.js
+++ b/platforms/taobao/wrapper/builtin/localStorage.js
@@ -12,11 +12,17 @@ const localStorage = {
   },
 
   getItem(key) {
-    return my.getStorageSync(key)
+    let ret =  my.getStorageSync({
+      key,
+    });
+    return ret && ret.data;
   },
 
-  setItem(key, value) {
-    return my.setStorageSync(key, value)
+  setItem(key, data) {
+    return my.setStorageSync({
+      key,
+      data,
+    });
   },
 
   removeItem(key) {

--- a/platforms/taobao/wrapper/builtin/requestAnimationFrame.js
+++ b/platforms/taobao/wrapper/builtin/requestAnimationFrame.js
@@ -1,4 +1,4 @@
 let screencanvas = $global.screencanvas;
-let requestAnimationFrame = screencanvas.requestAnimationFrame;
+let requestAnimationFrame = screencanvas.requestAnimationFrame.bind(screencanvas);
 
 export default requestAnimationFrame;

--- a/platforms/taobao/wrapper/builtin/window.js
+++ b/platforms/taobao/wrapper/builtin/window.js
@@ -9,5 +9,6 @@ export WebGLRenderingContext from './WebGLRenderingContext'
 export localStorage from './localStorage'
 export location from './location'
 export requestAnimationFrame from './requestAnimationFrame'
+export cancelAnimationFrame from './cancelAnimationFrame'
 export * from './WindowProperties'
 

--- a/platforms/taobao/wrapper/builtin/window.js
+++ b/platforms/taobao/wrapper/builtin/window.js
@@ -1,6 +1,7 @@
 export navigator from './navigator'
 export WebSocket from './WebSocket'
 export Image from './Image'
+export ImageBitmap from './ImageBitmap'
 export HTMLElement from './HTMLElement'
 export HTMLImageElement from './HTMLImageElement'
 export HTMLCanvasElement from './HTMLCanvasElement'

--- a/platforms/taobao/wrapper/engine/AssetManager.js
+++ b/platforms/taobao/wrapper/engine/AssetManager.js
@@ -1,0 +1,24 @@
+const parser = cc.assetManager.parser;
+const downloader = cc.assetManager.downloader;
+
+function doNothing (url, options, onComplete) {
+    onComplete(null, url);
+}
+
+downloader.downloadDomAudio = doNothing;
+
+downloader.register({
+    // Audio
+    '.mp3' : doNothing,
+    '.ogg' : doNothing,
+    '.wav' : doNothing,
+    '.m4a' : doNothing,
+});
+
+parser.register({
+    // Audio
+    '.mp3' : doNothing,
+    '.ogg' : doNothing,
+    '.wav' : doNothing,
+    '.m4a' : doNothing,
+});

--- a/platforms/taobao/wrapper/engine/Audio.js
+++ b/platforms/taobao/wrapper/engine/Audio.js
@@ -1,7 +1,15 @@
 const Audio = cc._Audio;
+const sys = cc.sys;
+
+const originalPlay = Audio.prototype.play;
+const originalSetCurrentTime = Audio.prototype.setCurrentTime;
+const originalStop = Audio.prototype.stop;
 
 if (Audio) {
     Object.assign(Audio.prototype, {
+        _currentTime: 0,
+        _hasPlayed: false,
+
         _createElement () {
             let url = this._src._nativeAsset;
             // Reuse dom audio element
@@ -9,6 +17,32 @@ if (Audio) {
                 this._element = __globalAdapter.createInnerAudioContext();
             }
             this._element.src = url;
+        },
+
+        play () {
+            this._hasPlayed = true;
+            originalPlay.call(this);
+            if (sys.os === sys.OS_ANDROID && this._currentTime !== 0 && this._element) {
+                this._element.seek(this._currentTime);
+                this._currentTime = 0;  // clear currentTime cache
+            }
+        },
+
+        stop () {
+            // HACK: on Android, can't call stop before first playing
+            if (sys.os === sys.OS_ANDROID && !this._hasPlayed) {
+                return;
+            }
+            originalStop.call(this);
+        },
+
+        setCurrentTime (num) {
+            // HACK: on Android, cannot call seek before playing
+            if (sys.os === sys.OS_ANDROID && this._element && this._element.paused) {
+                this._currentTime = num;
+            } else {
+                originalSetCurrentTime.call(this, num);
+            }
         },
     });
 }

--- a/platforms/taobao/wrapper/engine/Audio.js
+++ b/platforms/taobao/wrapper/engine/Audio.js
@@ -2,22 +2,13 @@ const Audio = cc._Audio;
 
 if (Audio) {
     Object.assign(Audio.prototype, {
-        getCurrentTime () {
-            if (this._element) {
-                // innerAudioContext.currentTime is not supported on Taobao platform.
-                return this._element.currentTime ? this._element.currentTime : 0;
-            } else {
-                return 0;
+        _createElement () {
+            let url = this._src._nativeAsset;
+            // Reuse dom audio element
+            if (!this._element) {
+                this._element = __globalAdapter.createInnerAudioContext();
             }
-        },
-        
-        getDuration: function () {
-            if (this._element) {
-                // innerAudioContext.duration is not supported on Taobao platform.
-                return this._element.duration ? this._element.duration : 1;
-            } else {
-                return 0;
-            }
+            this._element.src = url;
         },
     });
 }

--- a/platforms/taobao/wrapper/engine/cache-manager.js
+++ b/platforms/taobao/wrapper/engine/cache-manager.js
@@ -1,0 +1,2 @@
+// NOTE: can't cache file on Taobao iOS end
+cc.assetManager.cacheManager.cacheEnabled = cc.sys.os !== cc.sys.OS_IOS;

--- a/platforms/taobao/wrapper/engine/index.js
+++ b/platforms/taobao/wrapper/engine/index.js
@@ -1,1 +1,2 @@
 require('./Audio');
+require('./AssetManager');

--- a/platforms/taobao/wrapper/engine/index.js
+++ b/platforms/taobao/wrapper/engine/index.js
@@ -1,2 +1,3 @@
 require('./Audio');
 require('./AssetManager');
+require('./cache-manager')


### PR DESCRIPTION
> # CHANGE LOG
- 修复真机上 $global.screencanvas.getBoundingClientRect 没定义的报错
- 添加全局变量  DOMParser HTMLCanvasElement HTMLImageElement performance
- 修复 window.innerWidth 的问题，在真机上 ，screenWidth 有乘过 dpr，windowWidth 没有
- 修复真机上 requestAnimationFrame 调用报错，这里是因为 this 应该指向  window.screencanvas
- mini.project.json 里添加 remote 资源白名单
- 修复真机上 touch 事件问题
- 支持 onShow onHide 事件
- 修复 cc.sys.localStorage 不可用的问题
- 修复 cancelAnimationFrame 调用报错
- iOS 端上禁用缓存，猜测 copyFile 实现有问题，或者淘宝自己会做清理

>  # AUDIO BUG FIX

这里不得不提一下，淘宝小程序上音频的坑特别多，下面列举打勾的部分表示已经做了容错，  
坑太多了，只能修修补补，基本没救了

## Android 端
- [x] 只能支持 https 加载，不能播放本地缓存音频
- [ ] onCanPlay 被实现为 onPlay 
- [x] first play 之前不能 seek stop，否则之后都无法 play
- [ ] seek 后 stop，继续 play，currentTime 不会更新，一直为 0

## iOS 端
- [ ] onCanPlay 不可用
- [x] seek 后自动播放


> # 总结下其他坑，打勾表示已做容错：

- [ ] downloadFile fail 不会回调，只会走 success，写入 404 字符串到下载的文件中
- [ ] downloadFile 在开发者工具上，不能加载缓存后的图片，直接导致了开发者工具上无法使用远程加载
- [ ] 开发者工具不能支持分包
- [x] requestAnimationFrame 的 this 需要指向 screencanvas 
- [x] screencanvas 没有实现 getBoundingClientRect
- [x] screenWidth 乘了 dpr，windowWidth 没有乘 dpr
- [x] iOS 端缓存会被清掉 / 或者说没法缓存？ 
- [ ] 加速计在安卓上无法使用

> # 遗留已知问题
- [ ] ~~真机上支持分包~~ (先不支持了，使用 remote bundle 作为替代方案吧)
- [ ] ~~真机上 Label 的渲染位置偏移~~ (定位到是淘宝的 `context.textAlign !== 'left'` 时，且文字带空格，fillText 的定位有问题)