### PR TITLE
optimize image loading on Taobao platform

### DIFF
--- a/platforms/taobao/wrapper/engine/AssetManager.js
+++ b/platforms/taobao/wrapper/engine/AssetManager.js
@@ -13,6 +13,19 @@ downloader.register({
     '.ogg' : doNothing,
     '.wav' : doNothing,
     '.m4a' : doNothing,
+
+    // Image
+    '.png' : doNothing,
+    '.jpg' : doNothing,
+    '.bmp' : doNothing,
+    '.jpeg' : doNothing,
+    '.gif' : doNothing,
+    '.ico' : doNothing,
+    '.tiff' : doNothing,
+    '.image' : doNothing,
+    '.webp' : doNothing,
+    '.pvr': doNothing,
+    '.pkm': doNothing,
 });
 
 parser.register({

--- a/platforms/taobao/wrapper/engine/index.js
+++ b/platforms/taobao/wrapper/engine/index.js
@@ -1,3 +1,3 @@
 require('./Audio');
 require('./AssetManager');
-require('./cache-manager')
+require('./cache-manager');


### PR DESCRIPTION
changeLog:
- 修复 淘宝开发者工具和 iOS端上 图片加载的问题，淘宝平台的研发反馈 他们底层的 Image 做了缓存，所以引擎层面不需要显式地通过 copyFile 缓存图片了（这样做反而遇到一些缓存文件加载的 bug）