### PR TITLE
fix blend func on Taobao platform

### DIFF
--- a/platforms/taobao/res/pages/index/index.axml
+++ b/platforms/taobao/res/pages/index/index.axml
@@ -1,4 +1,4 @@
-<view class="canvas-element" style="flex-direction:row;display:flex;flex:1;">
+<view class="canvas-element" style="flex-direction:row;display:flex;flex:1;background-color:rgba(0,0,0,1);">
   <canvas 
   id="GameCanvas" 
   type="webgl" 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/3381

changeLog:
- 修复淘宝平台半透明像素混合结果偏亮的问题

原因是真机环境，像素跟 canvas 标签背后的白色背景做了一次混合

<img width="1377" alt="1" src="https://user-images.githubusercontent.com/17872773/121621740-5800f280-ca9f-11eb-880a-99e246c1cefd.png">
