### PR TITLE
fix Taobao crashing on gl.texSubImage2D

### DIFF
--- a/platforms/taobao/wrapper/engine/Label.js
+++ b/platforms/taobao/wrapper/engine/Label.js
@@ -4,7 +4,7 @@ if (cc && cc.Label) {
     const CacheMode = Label.CacheMode;
 
     // shared label canvas
-    let _sharedLabelCanvas = document.createElement('canvas');
+    let _sharedLabelCanvas = my.createOffscreenCanvas();
     let _sharedLabelCanvasCtx = _sharedLabelCanvas.getContext('2d');
     let canvasData = {
         canvas: _sharedLabelCanvas,

--- a/platforms/taobao/wrapper/engine/Label.js
+++ b/platforms/taobao/wrapper/engine/Label.js
@@ -1,6 +1,7 @@
 if (cc && cc.Label) {
     const gfx = cc.gfx;
     const Label = cc.Label;
+    const CacheMode = Label.CacheMode;
 
     // shared label canvas
     let _sharedLabelCanvas = document.createElement('canvas');
@@ -22,8 +23,17 @@ if (cc && cc.Label) {
     });
 
     let _originUpdateMaterial = Label.prototype._updateMaterialWebgl;
+    let _originOnEnable = Label.prototype.onEnable;
     // fix ttf font black border
     Object.assign(Label.prototype, {
+        onEnable () {
+            _originOnEnable.call(this);
+            // NOTE: fix crashing on gl.texSubImage2D()
+            if (this.cacheMode === CacheMode.CHAR) {
+                this.cacheMode = CacheMode.NONE;
+            }
+        },
+
         _updateMaterialWebgl () {
             _originUpdateMaterial.call(this);
 


### PR DESCRIPTION
changeLog:
- 禁用 Label char 缓存模式，修复淘宝平台 调用 `gl.texSubImage2D()` 导致崩溃的问题